### PR TITLE
Core: add PublishDelay

### DIFF
--- a/core/local.go
+++ b/core/local.go
@@ -190,7 +190,7 @@ func (client *localSubscriber) PublishDelay(tags []string, data string, delay ti
 	}
 	go func() {
 		time.Sleep(delay)
-	    client.Publish(tags, data)
+		client.Publish(tags, data)
 	}()
 	return nil
 }

--- a/core/local.go
+++ b/core/local.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nanopack/mist/subscription"
 	"sort"
 	"sync"
+	"time"
 )
 
 type (
@@ -179,6 +180,18 @@ func (client *localSubscriber) Publish(tags []string, data string) error {
 	default:
 		client.mist.Publish(tags, data)
 	}
+	return nil
+}
+
+// Sends a message with delay
+func (client *localSubscriber) PublishDelay(tags []string, data string, delay time.Duration) error {
+	if client.internal {
+		return InternalErr
+	}
+	go func() {
+		time.Sleep(delay)
+	    client.Publish(tags, data)
+	}()
 	return nil
 }
 

--- a/core/mist.go
+++ b/core/mist.go
@@ -10,6 +10,7 @@ package mist
 import (
 	"sort"
 	"sync/atomic"
+	"time"
 )
 
 type (
@@ -20,6 +21,7 @@ type (
 		Subscribe(tags []string) error
 		Unsubscribe(tags []string) error
 		Publish(tags []string, data string) error
+		PublishDelay(tags []string, data string, delay time.Duration) error
 		Ping() error
 		Messages() <-chan Message
 		Close() error

--- a/core/mist_test.go
+++ b/core/mist_test.go
@@ -124,7 +124,7 @@ func TestMistApi(test *testing.T) {
 	assert(test, ok, "got a nil message")
 	assert(test, msg.Data == "message", "got the wrong message %v", msg.Data)
 
-	client.PublishDelay([]string{"tag"}, "message_delay", 10 * time.Millisecond)
+	client.PublishDelay([]string{"tag"}, "message_delay", 10*time.Millisecond)
 	msg, ok = <-client.Messages()
 
 	assert(test, ok, "got a nil message")

--- a/core/mist_test.go
+++ b/core/mist_test.go
@@ -124,6 +124,12 @@ func TestMistApi(test *testing.T) {
 	assert(test, ok, "got a nil message")
 	assert(test, msg.Data == "message", "got the wrong message %v", msg.Data)
 
+	client.PublishDelay([]string{"tag"}, "message_delay", 10 * time.Millisecond)
+	msg, ok = <-client.Messages()
+
+	assert(test, ok, "got a nil message")
+	assert(test, msg.Data == "message_delay", "got the wrong message %v", msg.Data)
+
 }
 
 func TestMistWebsocket(test *testing.T) {

--- a/core/remote.go
+++ b/core/remote.go
@@ -181,11 +181,10 @@ func (client *remoteSubscriber) Publish(tags []string, data string) error {
 func (client *remoteSubscriber) PublishDelay(tags []string, data string, delay time.Duration) error {
 	go func() {
 		time.Sleep(delay)
-	    client.Publish(tags, data)
+		client.Publish(tags, data)
 	}()
 	return nil
 }
-
 
 // Ping pong the server
 func (client *remoteSubscriber) Ping() error {

--- a/core/remote.go
+++ b/core/remote.go
@@ -176,6 +176,17 @@ func (client *remoteSubscriber) Publish(tags []string, data string) error {
 	return client.async("publish %v %v\n", strings.Join(tags, ","), data)
 }
 
+// PublishDelay sends a message to the mist server to be published to all subscribed clients
+// with delay
+func (client *remoteSubscriber) PublishDelay(tags []string, data string, delay time.Duration) error {
+	go func() {
+		time.Sleep(delay)
+	    client.Publish(tags, data)
+	}()
+	return nil
+}
+
+
 // Ping pong the server
 func (client *remoteSubscriber) Ping() error {
 	remoteReply := client.sync("ping\n")

--- a/core/websocket.go
+++ b/core/websocket.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/gorilla/websocket"
 	"net/http"
+	"time"
 )
 
 var (
@@ -286,6 +287,10 @@ func (client *websocketClient) Unsubscribe(tags []string) error {
 }
 
 func (client *websocketClient) Publish(tags []string, data string) error {
+	return NotSupported
+}
+
+func (client *websocketClient) PublishDelay(tags []string, data string, delay time.Duration) error {
 	return NotSupported
 }
 


### PR DESCRIPTION
Just added ```PublishDelay``` method to client. It could be helpful, if you want to send some message, but not immediately and with some delay.